### PR TITLE
Removed ExpectedException from unit testing

### DIFF
--- a/MoreLinq.Test/ExceptAllByTest.cs
+++ b/MoreLinq.Test/ExceptAllByTest.cs
@@ -34,30 +34,30 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullFirstSequence()
         {
             string[] first = null;
             string[] second = { "aaa" };
-            first.ExceptAllBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptAllBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullSecondSequence()
         {
             string[] first = { "aaa" };
             string[] second = null;
-            first.ExceptAllBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptAllBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullKeySelector()
         {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.ExceptAllBy(second, (Func<string, string>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptAllBy(second, (Func<string, string>)null));
         }
         
         [Test]
@@ -85,30 +85,30 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullFirstSequenceWithComparer()
         {
             string[] first = null;
             string[] second = { "aaa" };
-            first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullSecondSequenceWithComparer()
         {
             string[] first = { "aaa" };
             string[] second = null;
-            first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllByNullKeySelectorWithComparer()
         {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.ExceptAllBy(second, null, EqualityComparer<string>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptAllBy(second, null, EqualityComparer<string>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/ExceptAllKeysTest.cs
+++ b/MoreLinq.Test/ExceptAllKeysTest.cs
@@ -34,32 +34,32 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullFirstSequence()
         {
             string[] first = null;
             int[] second = { 1 };
-            first.ExceptAllKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptAllKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullSecondSequence()
         {
             string[] first = { "aaa" };
             int[] second = null;
-            first.ExceptAllKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptAllKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullKeySelector()
         {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.ExceptAllKeys(second, (Func<string, int>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptAllKeys(second, (Func<string, int>)null));
         }
-        
+
         [Test]
         public void ExceptAllKeysIsLazy()
         {
@@ -79,36 +79,36 @@ namespace MoreLinq.Test
         public void ExceptAllKeysWithComparer()
         {
             string[] first = { "first", "second", "third", "fourth" };
-            string[] second = { "FIRST" , "thiRD", "FIFTH" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
             var result = first.ExceptAllKeys(second, word => word, StringComparer.OrdinalIgnoreCase);
             result.AssertSequenceEqual("second", "fourth");
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullFirstSequenceWithComparer()
         {
             string[] first = null;
             int[] second = { 1 };
-            first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullSecondSequenceWithComparer()
         {
             string[] first = { "aaa" };
             int[] second = null;
-            first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptAllKeysNullKeySelectorWithComparer()
         {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.ExceptAllKeys(second, null, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptAllKeys(second, null, EqualityComparer<int>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/ExceptKeysTest.cs
+++ b/MoreLinq.Test/ExceptKeysTest.cs
@@ -34,30 +34,30 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullFirstSequence()
         {
             string[] first = null;
             int[] second = { 1 };
-            first.ExceptKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullSecondSequence()
         {
             string[] first = { "aaa" };
             int[] second = null;
-            first.ExceptKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullKeySelector()
         {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.ExceptKeys(second, (Func<string, int>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptKeys(second, (Func<string, int>)null));
         }
         
         [Test]
@@ -85,30 +85,30 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullFirstSequenceWithComparer()
         {
             string[] first = null;
             int[] second = { 1 };
-            first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullSecondSequenceWithComparer()
         {
             string[] first = { "aaa" };
             int[] second = null;
-            first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void ExceptKeysNullKeySelectorWithComparer()
         {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.ExceptKeys(second, null, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.ExceptKeys(second, null, EqualityComparer<int>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/IntersectAllByTest.cs
+++ b/MoreLinq.Test/IntersectAllByTest.cs
@@ -31,27 +31,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullFirstSequence() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.IntersectAllBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectAllBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullSecondSequence() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.IntersectAllBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectAllBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullKeySelector() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.IntersectAllBy<string, string>(second, (Func<string, string>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () => 
+             first.IntersectAllBy<string, string>(second, (Func<string, string>)null));
         }
 
         [Test]
@@ -76,27 +76,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullFirstSequenceWithComparer() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullSecondSequenceWithComparer() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllByNullKeySelectorWithComparer() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.IntersectAllBy(second, null, EqualityComparer<string>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectAllBy(second, null, EqualityComparer<string>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/IntersectAllKeysTest.cs
+++ b/MoreLinq.Test/IntersectAllKeysTest.cs
@@ -31,27 +31,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullFirstSequence() {
             string[] first = null;
             int[] second = { 1 };
-            first.IntersectAllKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectAllKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullSecondSequence() {
             string[] first = { "aaa" };
             int[] second = null;
-            first.IntersectAllKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectAllKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullKeySelector() {
             string[] first = { "aaa" };
             int[] second = { 3 };
-            first.IntersectAllKeys<string, int>(second, (Func<string, int>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectAllKeys<string, int>(second, (Func<string, int>)null));
         }
 
         [Test]
@@ -76,27 +76,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullFirstSequenceWithComparer() {
             string[] first = null;
             int[] second = { 1 };
-            first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullSecondSequenceWithComparer() {
             string[] first = { "aaa" };
             int[] second = null;
-            first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectAllKeysNullKeySelectorWithComparer() {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.IntersectAllKeys(second, null, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectAllKeys(second, null, EqualityComparer<int>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/IntersectByTest.cs
+++ b/MoreLinq.Test/IntersectByTest.cs
@@ -31,27 +31,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullFirstSequence() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.IntersectBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullSecondSequence() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.IntersectBy(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectBy(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullKeySelector() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.IntersectBy<string, string>(second, (Func<string, string>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectBy<string, string>(second, (Func<string, string>)null));
         }
 
         [Test]
@@ -76,27 +76,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullFirstSequenceWithComparer() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () => 
+            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullSecondSequenceWithComparer() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectByNullKeySelectorWithComparer() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.IntersectBy(second, null, EqualityComparer<string>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectBy(second, null, EqualityComparer<string>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/IntersectKeysTest.cs
+++ b/MoreLinq.Test/IntersectKeysTest.cs
@@ -31,27 +31,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullFirstSequence() {
             string[] first = null;
             int[] second = { 1 };
-            first.IntersectKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullSecondSequence() {
             string[] first = { "aaa" };
             int[] second = null;
-            first.IntersectKeys(second, x => x.Length);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectKeys(second, x => x.Length));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullKeySelector() {
             string[] first = { "aaa" };
             int[] second = { 3 };
-            first.IntersectKeys<string, int>(second, (Func<string, int>)null);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectKeys<string, int>(second, (Func<string, int>)null));
         }
 
         [Test]
@@ -76,27 +76,27 @@ namespace MoreLinq.Test {
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullFirstSequenceWithComparer() {
             string[] first = null;
             int[] second = { 1 };
-            first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("first", () =>
+             first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullSecondSequenceWithComparer() {
             string[] first = { "aaa" };
             int[] second = null;
-            first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("second", () =>
+             first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void IntersectKeysNullKeySelectorWithComparer() {
             string[] first = { "aaa" };
             int[] second = { 1 };
-            first.IntersectKeys(second, null, EqualityComparer<int>.Default);
+            Assert.ThrowsArgumentNullException("keySelector", () =>
+             first.IntersectKeys(second, null, EqualityComparer<int>.Default));
         }
 
         [Test]


### PR DESCRIPTION
Since NUnit v3 ExpectedException is not supported anymore so this caused PR #169 to fail,  so i replaced
all tests with the ThrowsArgumentNullException method.